### PR TITLE
Add Debian/Ubuntu Compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ icinga2_cs_host_template: "generic-host-template #value for template to import i
 icinga2_cs_host_display_name: "My Appserver" #value for display_name in host config | DEFAULT: undefined
 icinga2_cs_host_notes "Owner: Hans Muster" #value for notes in host config | DEFAULT: undefined
 icinga2_cs_host_custom_block: "" #custom block to include in host config | DEFAULT: undefined
+icinga2_cs_host_groups: #array of vars to include in groups via `groups +=` | DEFAULT: undefined
 icinga2_cs_host_vars: #array of vars to include in host config | DEFAULT: undefined
  - os: windows
  - role: dc

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,7 +9,8 @@ icinga2_node_zone: "{{ icinga2_node_endpoint }}"
 icinga2_node_endpoint: "{{ inventory_hostname }}"
 icinga2_node_global_zone: global-templates
 icinga2_node_features: [api, checker, mainlog]
-icinga2_node_nagios_plugins: [nagios-plugins-all]
+icinga2_node_nagios_plugins_rh: [nagios-plugins-all]
+icinga2_node_nagios_plugins_deb: [nagios-plugins-contrib]
 icinga2_node_service_password: ""
 icinga2_node_service_delayed: no
 icinga2_node_local_conf: no

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,6 +18,8 @@ icinga2_node_sync_ca: no
 icinga2_node_service_restart: yes
 icinga2_node_repo_icinga_install: yes
 icinga2_node_repo_epel_install: yes
+icinga2_node_owner:  "{% if ansible_os_family == 'Debian' %}nagios{% else %}icinga{% endif %}"
+icinga2_node_group:  "{% if ansible_os_family == 'Debian' %}nagios{% else %}icinga{% endif %}"
 icinga2_chocolatey_retries: 5
 icinga2_chocolatey_delay: 10
 icinga2_restart_on_failure: yes

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -125,8 +125,9 @@ galaxy_info:
   #  - 9.1
   #  - 9.2
   #  - 9.3
-  #- name: Ubuntu
-  #  versions:
+  - name: Ubuntu
+    versions:
+    - focal
   #  - all
   #  - lucid
   #  - maverick
@@ -142,11 +143,11 @@ galaxy_info:
   #  - wily
   #  - xenial
   #  - yakkety
-  #- name: Debian
-  #  versions:
+  - name: Debian
+    versions:
   #  - all
-  #  - etch
-  #  - jessie
+    - etch
+    - jessie
   #  - lenny
   #  - sid
   #  - squeeze

--- a/tasks/linux.yml
+++ b/tasks/linux.yml
@@ -44,11 +44,25 @@
     apt:
       name: icinga2
       state: latest  # noqa 403
+      cache_valid_time: 86400
 
   - name: ensure nagios-plugins are installed (Debian)
     apt:
       name: "{{ icinga2_node_nagios_plugins_deb }}"
       state: latest  # noqa 403
+      cache_valid_time: 86400
+
+  - name: Ensure ownership of /etc/icinga2 subdirs
+    # Ubuntu and Debian install everything as owned by root:root, which prevents all
+    # the automation later. Reported to Debian in 2016 at
+    # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=824482,
+    # apparently still a problem on Ubuntu in 2022.
+    file:
+      state: directory
+      path: /etc/icinga2
+      recurse: yes
+      owner: "{{ icinga2_node_owner }}"
+      group: "{{ icinga2_node_group }}"
 
 - name: ensure icinga2 service restarts on failure
   blockinfile:

--- a/tasks/linux.yml
+++ b/tasks/linux.yml
@@ -9,24 +9,46 @@
     delay: 0
     timeout: 10
 
-- name: ensure icinga2 repository is installed
-  yum:
-    name: "{{ icinga2_repo_icinga_url }}"
-  when: icinga2_node_repo_icinga_install
+- name: Install Icinga2 (RedHat)
+  when: ansible_os_family == "RedHat" or ansible_os_family == "Rocky"
+  block:
+  - name: ensure icinga2 repository is installed
+    yum:
+      name: "{{ icinga2_repo_icinga_url }}"
+    when: icinga2_node_repo_icinga_install
 
-- name: ensure epel-release is installed
-  yum:
-    name: epel-release
-    state: present
-  when: icinga2_node_repo_epel_install
-  tags:
-    - molecule-idempotence-notest
+  - name: ensure epel-release is installed
+    yum:
+      name: epel-release
+      state: present
+    when: icinga2_node_repo_epel_install
+    tags:
+      - molecule-idempotence-notest
 
-- name: ensure icinga2 is installed
-  yum:
-    name: icinga2
-    disable_gpg_check: yes
-    state: latest  # noqa 403
+  - name: ensure icinga2 is installed (RedHat)
+    yum:
+      name: icinga2
+      disable_gpg_check: yes
+      state: latest  # noqa 403
+
+  - name: ensure nagios-plugins are installed (RedHat)
+    yum:
+      name: "{{ icinga2_node_nagios_plugins_rh }}"
+      state: latest  # noqa 403
+
+
+- name: Install Icinga2 (Debian)
+  when: ansible_os_family == "Debian"
+  block:
+  - name: ensure icinga2 is installed (Debian)
+    apt:
+      name: icinga2
+      state: latest  # noqa 403
+
+  - name: ensure nagios-plugins are installed (Debian)
+    apt:
+      name: "{{ icinga2_node_nagios_plugins_deb }}"
+      state: latest  # noqa 403
 
 - name: ensure icinga2 service restarts on failure
   blockinfile:
@@ -44,11 +66,6 @@
   service:
     name: icinga2
     enabled: true
-
-- name: ensure nagios-plugins are installed
-  yum:
-    name: "{{ icinga2_node_nagios_plugins }}"
-    state: latest  # noqa 403
 
 - name: ensure rpcbind.socket is disabled
   systemd:

--- a/tasks/linux.yml
+++ b/tasks/linux.yml
@@ -15,6 +15,7 @@
   - name: ensure icinga2 repository is installed
     yum:
       name: "{{ icinga2_repo_icinga_url }}"
+      disable_gpg_check: yes
     when: icinga2_node_repo_icinga_install
 
   - name: ensure epel-release is installed
@@ -44,7 +45,7 @@
     apt:
       name: icinga2
       state: latest  # noqa 403
-      cache_valid_time: 86400
+      update_cache: yes
 
   - name: ensure nagios-plugins are installed (Debian)
     apt:

--- a/tasks/linux_config.yml
+++ b/tasks/linux_config.yml
@@ -9,8 +9,8 @@
 #- name: ensure /usr/lib64/nagios/plugins/* is owned by icinga:icinga
 #  file:
 #    path: /usr/lib64/nagios/plugins
-#    owner: icinga
-#    group: icinga
+#    owner: "{{ icinga2_node_owner }}"
+#    group: "{{ icinga2_node_group }}"
 #    state: directory
 #    recurse: true
 
@@ -19,13 +19,14 @@
     name: icinga
     groups: nagios
     append: yes
+  when: not ansible_os_family == "Debian"
 
 - name: ensure directory /var/lib/icinga2/ca is present
   file:
     path: /var/lib/icinga2/ca
     state: directory
-    owner: icinga
-    group: icinga
+    owner: "{{ icinga2_node_owner }}"
+    group: "{{ icinga2_node_group }}"
   when: icinga2_node_sync_ca
 
 - name: get /var/lib/icinga2/ca/ca.crt contents from caserver
@@ -53,8 +54,8 @@
   copy:
     content: "{{ ca_crt['content'] | b64decode }}"
     dest: /var/lib/icinga2/ca/ca.crt
-    owner: icinga
-    group: icinga
+    owner: "{{ icinga2_node_owner }}"
+    group: "{{ icinga2_node_group }}"
     mode: 0644
   when: icinga2_node_sync_ca
 
@@ -62,8 +63,8 @@
   copy:
     content: "{{ ca_key['content'] | b64decode }}"
     dest: /var/lib/icinga2/ca/ca.key
-    owner: icinga
-    group: icinga
+    owner: "{{ icinga2_node_owner }}"
+    group: "{{ icinga2_node_group }}"
     mode: 0600
   when: icinga2_node_sync_ca
 
@@ -71,8 +72,8 @@
   copy:
     content: "{{ ca_serial['content'] | b64decode }}"
     dest: /var/lib/icinga2/ca/serial.txt
-    owner: icinga
-    group: icinga
+    owner: "{{ icinga2_node_owner }}"
+    group: "{{ icinga2_node_group }}"
     mode: 0644
   when: icinga2_node_sync_ca
 
@@ -80,8 +81,8 @@
   file:
     path: /etc/icinga2/pki
     state: directory
-    owner: icinga
-    group: icinga
+    owner: "{{ icinga2_node_owner }}"
+    group: "{{ icinga2_node_group }}"
 
 - name: check if pki key already exists
   stat:
@@ -139,8 +140,8 @@
   file:
     src: "/etc/icinga2/features-available/{{ item }}.conf"
     dest: "/etc/icinga2/features-enabled/{{ item }}.conf"
-    owner: icinga
-    group: icinga
+    owner: "{{ icinga2_node_owner }}"
+    group: "{{ icinga2_node_group }}"
     state: link
   with_items: "{{ icinga2_node_features }}"
   notify: linux node restart icinga2 service
@@ -149,16 +150,16 @@
   template:
     src: icinga2.conf.j2
     dest: /etc/icinga2/icinga2.conf
-    owner: icinga
-    group: icinga
+    owner: "{{ icinga2_node_owner }}"
+    group: "{{ icinga2_node_group }}"
   notify: linux node restart icinga2 service
 
 - name: ensure zones.conf corresponds to template
   template:
     src: zones.conf.j2
     dest: /etc/icinga2/zones.conf
-    owner: icinga
-    group: icinga
+    owner: "{{ icinga2_node_owner }}"
+    group: "{{ icinga2_node_group }}"
   notify: linux node restart icinga2 service
 
 - name: ensure NodeName constant is set

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,7 +23,7 @@
   when: icinga2_node_sync_ca
 
 - include: "linux.yml"
-  when: ansible_os_family == "RedHat" or ansible_os_family == "Rocky"
+  when: ansible_os_family == "RedHat" or ansible_os_family == "Rocky" or ansible_os_family == "Debian"
 
 - include: "windows.yml"
   when: (ansible_os_family == "Windows")

--- a/templates/host.conf.j2
+++ b/templates/host.conf.j2
@@ -8,6 +8,14 @@ object Host "{{ icinga2_cs_host_objectname }}" {
 {% if icinga2_cs_host_notes is defined %}
   notes = "{{ icinga2_cs_host_notes }}"
 {% endif %}
+{% if icinga2_cs_host_groups is defined %}
+  groups += [
+    {%- for g in icinga2_cs_host_groups %}
+	{{'\n    "' + g + '",'}}
+	{%- endfor %}
+
+  ]
+{% endif %}
 {% if icinga2_cs_host_check_command is defined %}
   check_command = "{{ icinga2_cs_host_check_command }}"
 {% endif %}


### PR DESCRIPTION
I've been using this role for over a year with CentOS 8. My company is shifting to Ubuntu (not to Rocky, sadly), so I needed to make some additions for the Debian family.

I've successfully deployed a node on Ubuntu 20.04.3 LTS Focal, but have not tested on any older versions or with Debian.